### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/DINAR.yml
+++ b/.github/workflows/DINAR.yml
@@ -83,7 +83,7 @@ jobs:
           password ${{ secrets.DINAR_TOKEN }}
           EOF
       - name: Build ${{ env.IMAGE_ODOO_BASE }}
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           LOCAL_CUSTOM_DIR: ./image
           AGGREGATE: true


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore